### PR TITLE
3 fix the conditions for modifying static text

### DIFF
--- a/src/HookUtil.hpp
+++ b/src/HookUtil.hpp
@@ -106,7 +106,7 @@ namespace Hook::stl {
                 fmt::format("Invalid target address for detour replace [{} + 0x{:X}]", a_relId.id(), a_relId.offset()));
         }
 
-        PVOID targetFunc = reinterpret_cast<PVOID>(target.address());
+        auto targetFunc = reinterpret_cast<PVOID>(target.address());
 
         DetourTransactionBegin();
         DetourUpdateThread(GetCurrentThread());

--- a/src/HookUtil.hpp
+++ b/src/HookUtil.hpp
@@ -84,8 +84,7 @@ namespace Hook::stl {
         DetourTransactionBegin();
         DetourUpdateThread(GetCurrentThread());
 
-        LONG attachResult = DetourAttach(&reinterpret_cast<PVOID&>(T::func), T::thunk);
-        if (attachResult != NO_ERROR) {
+        if (LONG attachResult = DetourAttach(&reinterpret_cast<PVOID&>(T::func), T::thunk); attachResult != NO_ERROR) {
             DetourTransactionAbort();
             SKSE::stl::report_and_fail(fmt::format("Detour Attach Failed [{} + 0x{:X}] - Error: {}", a_relId.id(),
                                                    a_relId.offset(), attachResult));
@@ -112,8 +111,7 @@ namespace Hook::stl {
         DetourTransactionBegin();
         DetourUpdateThread(GetCurrentThread());
 
-        LONG attachResult = DetourAttach(&targetFunc, T::thunk);
-        if (attachResult != NO_ERROR) {
+        if (LONG attachResult = DetourAttach(&targetFunc, T::thunk); attachResult != NO_ERROR) {
             DetourTransactionAbort();
             SKSE::stl::report_and_fail(fmt::format("Detour Replace Attach Failed [{} + 0x{:X}] - Error: {}",
                                                    a_relId.id(), a_relId.offset(), attachResult));
@@ -143,8 +141,8 @@ namespace Hook::stl {
         DetourTransactionBegin();
         DetourUpdateThread(GetCurrentThread());
 
-        LONG attachResult = DetourAttach(&reinterpret_cast<PVOID&>(vtable[idx]), T::thunk);
-        if (attachResult != NO_ERROR) {
+        if (LONG attachResult = DetourAttach(&reinterpret_cast<PVOID&>(vtable[idx]), T::thunk);
+            attachResult != NO_ERROR) {
             DetourTransactionAbort();
             SKSE::stl::report_and_fail(
                 fmt::format("Detour vFunc Attach Failed at index {} - Error: {}", idx, attachResult));

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -57,7 +57,6 @@ namespace RDDM {
             std::scoped_lock lock(g_magMutex);
             auto it = g_lastFormattedMag.find(mgef);
             if (it == g_lastFormattedMag.end()) {
-                spdlog::info("[MagFmt] inside='sec' mas sem mag cacheado para {:08X}", mgef->formID);
                 return full;
             }
             cachedMag = it->second;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -21,6 +21,11 @@ namespace RDDM {
     static std::mutex g_magMutex;                          // NOSONAR: Mutex for g_lastFormattedMag
     static std::unordered_map<RE::EffectSetting*, double>  // NOSONAR: Cache of last formatted magnitudes
         g_lastFormattedMag;
+    constexpr RE::FormID kUnboundedStormsMgef = 0xFE009807;
+    constexpr RE::FormID kUnboundedFreezingMgef = 0xFE009809;
+    constexpr RE::FormID kCloakFrostMgef = 0x0003AEA0;
+    constexpr RE::FormID kCloakShockMgef = 0x0003AEA1;
+    constexpr RE::FormID kBlizzardMgef = 0x000B79FE;
 
     std::string OnEffectFormatted(RE::Effect* effect, std::string full, const std::string& inside, const std::string&,
                                   const std::string&) {
@@ -44,7 +49,6 @@ namespace RDDM {
         if (isNumber) {
             std::scoped_lock lock(g_magMutex);
             g_lastFormattedMag[mgef] = magVal;
-
             return full;
         }
 
@@ -62,16 +66,41 @@ namespace RDDM {
             cachedMag = it->second;
         }
 
+        const auto formID = mgef->GetFormID();
+
+        bool isHealthStamina = Common::IsDV_Health_Stamina(mgef);
+        bool isHealthMagicka = Common::IsDV_Health_Magicka(mgef);
+
+        if (formID == kUnboundedStormsMgef || formID == kCloakShockMgef) {
+            isHealthMagicka = true;
+        }
+
+        if (formID == kUnboundedFreezingMgef || formID == kCloakFrostMgef || formID == kBlizzardMgef) {
+            isHealthStamina = true;
+        }
+
         double slider = 1.0;
-        if (Common::IsDV_Health_Stamina(mgef)) {
+        if (isHealthStamina) {
             slider = GetScaling().frostStamina.load(std::memory_order_relaxed);
-        } else if (Common::IsDV_Health_Magicka(mgef)) {
+        } else if (isHealthMagicka) {
             slider = GetScaling().shockMagicka.load(std::memory_order_relaxed);
         } else {
             return full;
         }
 
-        double secD = cachedMag * static_cast<double>(mgef->data.secondAVWeight) * slider;
+        auto secondWeight = static_cast<double>(mgef->data.secondAVWeight);
+
+        if (formID == kUnboundedStormsMgef && secondWeight <= 0.0) {
+            secondWeight = 0.5;
+        }
+
+        if ((formID == kUnboundedFreezingMgef || formID == kCloakFrostMgef || formID == kCloakShockMgef ||
+             formID == kBlizzardMgef) &&
+            secondWeight <= 0.0) {
+            secondWeight = 1.0;
+        }
+
+        double secD = cachedMag * secondWeight * slider;
         long long sec = std::llround(secD);
         if (sec < 0) {
             sec = 0;

--- a/src/MagFormatHook.hpp
+++ b/src/MagFormatHook.hpp
@@ -39,100 +39,10 @@ private:
         }
     };
 
-    static void LogBaseEffect(RE::Effect* eff) {
-        std::uint32_t formID = 0;
-        if (eff) {
-            if (auto base = eff->baseEffect; base) {
-                formID = base->formID;
-            }
-        }
-    }
-
     static_assert(offsetof(EffectStruct, buffer) == 0x00);
     static_assert(offsetof(EffectStruct, effect) == 0x10);
     static_assert(offsetof(EffectStruct, prefix) == 0x18);
     static_assert(offsetof(EffectStruct, suffix) == 0x20);
-
-    struct CallEffectA {
-        inline static std::uintptr_t func = 0;
-
-        static const char* thunk(EffectStruct* arg, char* type, char* unused, char* edid) {
-            using Fn = const char* (*)(EffectStruct*, char*, char*, char*);
-
-            if (!arg) {
-                auto orig = reinterpret_cast<Fn>(func);
-                return orig ? orig(arg, type, unused, edid) : nullptr;
-            }
-
-            const auto ps = StringData(arg);
-            LogBaseEffect(arg->effect.common);
-
-            auto orig = reinterpret_cast<Fn>(func);
-            auto result = orig ? orig(arg, type, unused, edid) : nullptr;
-            if (!result) {
-                return result;
-            }
-
-            const std::size_t fSize = std::strlen(result);
-            std::string full = result;
-            std::string inside = full.substr(ps.pSize, fSize - ps.pSize - ps.sSize);
-
-            if (std::string newFull = RDDM::OnEffectFormatted(arg->effect.common, std::move(full), inside, ps.p, ps.s);
-                newFull != result) {
-                arg->buffer = newFull.c_str();
-                result = arg->buffer.c_str();
-            }
-
-            return result;
-        }
-
-        static void Install() {
-            Hook::stl::write_call<CallEffectA>(REL::VariantID(10937, 11027, 0x108FF0),
-                                               REL::VariantOffset(0x1AD, 0x2B2, 0x1AD));
-        }
-    };
-
-    struct CallActiveEffect {
-        inline static std::uintptr_t func = 0;
-
-        static const char* thunk(EffectStruct* arg, char* type, char* unused, char* edid) {
-            using Fn = const char* (*)(EffectStruct*, char*, char*, char*);
-
-            if (!arg) {
-                auto orig = reinterpret_cast<Fn>(func);
-                return orig ? orig(arg, type, unused, edid) : nullptr;
-            }
-
-            const auto ps = StringData(arg);
-            auto active = arg->effect.active;
-            RE::Effect* eff = active ? active->effect : nullptr;
-
-            LogBaseEffect(eff);
-
-            auto orig = reinterpret_cast<Fn>(func);
-            auto result = orig ? orig(arg, type, unused, edid) : nullptr;
-            if (!result) {
-                return result;
-            }
-
-            const std::size_t fSize = std::strlen(result);
-            std::string full = result;
-            std::string inside = full.substr(ps.pSize, fSize - ps.pSize - ps.sSize);
-
-            if (std::string newFull = RDDM::OnEffectFormatted(eff, std::move(full), inside, ps.p, ps.s);
-                newFull != result) {
-                arg->buffer = newFull.c_str();
-                result = arg->buffer.c_str();
-            }
-
-            return result;
-        }
-
-        static void Install() {
-            Hook::stl::write_call<CallActiveEffect>(REL::VariantID(33326, 34105, 0x543320),
-                                                    REL::VariantOffset(0x1AD, 0x2B2, 0x1AD));
-        }
-    };
 
     struct CallEffectB {
         inline static std::uintptr_t func = 0;
@@ -146,7 +56,6 @@ private:
             }
 
             const auto ps = StringData(arg);
-            LogBaseEffect(arg->effect.common);
 
             auto orig = reinterpret_cast<Fn>(func);
             auto result = orig ? orig(arg, type, unused, edid) : nullptr;
@@ -174,9 +83,5 @@ private:
     };
 
 public:
-    static void Install() {
-        CallEffectA::Install();
-        CallActiveEffect::Install();
-        CallEffectB::Install();
-    }
+    static void Install() { CallEffectB::Install(); }
 };

--- a/src/MagFormatHook.hpp
+++ b/src/MagFormatHook.hpp
@@ -28,7 +28,7 @@ private:
         std::size_t pSize;
         std::size_t sSize;
 
-        StringData(EffectStruct* arg) {
+        explicit StringData(EffectStruct* arg) {
             auto prefixPtr = arg->prefix;
             auto suffixPtr = arg->suffix;
 
@@ -46,7 +46,6 @@ private:
                 formID = base->formID;
             }
         }
-        spdlog::info("MagFormatHook: baseEffect = {:08X}", formID);
     }
 
     static_assert(offsetof(EffectStruct, buffer) == 0x00);
@@ -58,11 +57,9 @@ private:
         inline static std::uintptr_t func = 0;
 
         static const char* thunk(EffectStruct* arg, char* type, char* unused, char* edid) {
-            spdlog::info("MagFormatHook.CallEffectA::thunk chamado");
             using Fn = const char* (*)(EffectStruct*, char*, char*, char*);
 
             if (!arg) {
-                spdlog::warn("MagFormatHook.CallEffectA: arg == nullptr (CTD vindo)");
                 auto orig = reinterpret_cast<Fn>(func);
                 return orig ? orig(arg, type, unused, edid) : nullptr;
             }
@@ -80,9 +77,8 @@ private:
             std::string full = result;
             std::string inside = full.substr(ps.pSize, fSize - ps.pSize - ps.sSize);
 
-            std::string newFull = RDDM::OnEffectFormatted(arg->effect.common, std::move(full), inside, ps.p, ps.s);
-
-            if (newFull != result) {
+            if (std::string newFull = RDDM::OnEffectFormatted(arg->effect.common, std::move(full), inside, ps.p, ps.s);
+                newFull != result) {
                 arg->buffer = newFull.c_str();
                 result = arg->buffer.c_str();
             }
@@ -93,8 +89,6 @@ private:
         static void Install() {
             Hook::stl::write_call<CallEffectA>(REL::VariantID(10937, 11027, 0x108FF0),
                                                REL::VariantOffset(0x1AD, 0x2B2, 0x1AD));
-
-            spdlog::info("MagFormatHook.CallEffectA instalado (func=0x{:X})", static_cast<unsigned>(func));
         }
     };
 
@@ -102,11 +96,9 @@ private:
         inline static std::uintptr_t func = 0;
 
         static const char* thunk(EffectStruct* arg, char* type, char* unused, char* edid) {
-            spdlog::info("MagFormatHook.CallActiveEffect::thunk chamado");
             using Fn = const char* (*)(EffectStruct*, char*, char*, char*);
 
             if (!arg) {
-                spdlog::warn("MagFormatHook.CallActiveEffect: arg == nullptr (CTD vindo)");
                 auto orig = reinterpret_cast<Fn>(func);
                 return orig ? orig(arg, type, unused, edid) : nullptr;
             }
@@ -127,9 +119,8 @@ private:
             std::string full = result;
             std::string inside = full.substr(ps.pSize, fSize - ps.pSize - ps.sSize);
 
-            std::string newFull = RDDM::OnEffectFormatted(eff, std::move(full), inside, ps.p, ps.s);
-
-            if (newFull != result) {
+            if (std::string newFull = RDDM::OnEffectFormatted(eff, std::move(full), inside, ps.p, ps.s);
+                newFull != result) {
                 arg->buffer = newFull.c_str();
                 result = arg->buffer.c_str();
             }
@@ -140,8 +131,6 @@ private:
         static void Install() {
             Hook::stl::write_call<CallActiveEffect>(REL::VariantID(33326, 34105, 0x543320),
                                                     REL::VariantOffset(0x1AD, 0x2B2, 0x1AD));
-
-            spdlog::info("MagFormatHook.CallActiveEffect instalado (func=0x{:X})", static_cast<unsigned>(func));
         }
     };
 
@@ -149,11 +138,9 @@ private:
         inline static std::uintptr_t func = 0;
 
         static const char* thunk(EffectStruct* arg, char* type, char* unused, char* edid) {
-            spdlog::info("MagFormatHook.CallEffectB::thunk chamado");
             using Fn = const char* (*)(EffectStruct*, char*, char*, char*);
 
             if (!arg) {
-                spdlog::warn("MagFormatHook.CallEffectB: arg == nullptr (CTD vindo)");
                 auto orig = reinterpret_cast<Fn>(func);
                 return orig ? orig(arg, type, unused, edid) : nullptr;
             }
@@ -167,18 +154,14 @@ private:
                 return result;
             }
 
-            spdlog::info("MagFormatHook.CallEffectB result after orig: '{}'", result);
-
             const std::size_t fSize = std::strlen(result);
             std::string full = result;
             std::string inside = full.substr(ps.pSize, fSize - ps.pSize - ps.sSize);
-            spdlog::info("MagFormatHook.CallEffectB full='{}' inside='{}'", full, inside);
 
             if (std::string newFull = RDDM::OnEffectFormatted(arg->effect.common, std::move(full), inside, ps.p, ps.s);
                 newFull != result) {
                 arg->buffer = newFull.c_str();
                 result = arg->buffer.c_str();
-                spdlog::info("MagFormatHook.CallEffectB newFull='{}'", result);
             }
 
             return result;
@@ -187,8 +170,6 @@ private:
         static void Install() {
             Hook::stl::write_call<CallEffectB>(REL::VariantID(51024, 51902, 0x8C0D60),
                                                REL::VariantOffset(0x1AD, 0x2B2, 0x1AD));
-
-            spdlog::info("MagFormatHook.CallEffectB instalado (func=0x{:X})", static_cast<unsigned>(func));
         }
     };
 

--- a/src/TextTemplates.cpp
+++ b/src/TextTemplates.cpp
@@ -24,6 +24,9 @@ namespace {
     constexpr RE::FormID kCloakFrost = 0x0003AEA0;
     constexpr RE::FormID kCloakShock = 0x0003AEA1;
 
+    constexpr const char* kExtraNeedle = "extra damage";
+    constexpr const char* kExtraSentence = " Targets on fire take extra damage over time.";
+
     void ApplyFireTaper(RE::EffectSetting* m, float fireMult) {
         if (!m) return;
 
@@ -53,84 +56,125 @@ namespace {
         std::string_view sv = m->magicItemDescription.c_str();
         return !sv.empty() && sv.contains("per second");
     }
-}
 
-inline void SetDesc(RE::EffectSetting* m, std::string_view s) { m->magicItemDescription = RE::BSFixedString{s.data()}; }
-
-inline bool SameDesc(const RE::EffectSetting* m, std::string_view s) {
-    const char* cur = m ? m->magicItemDescription.c_str() : nullptr;
-    return cur && s == cur;
-}
-
-enum class AreaClass { None, Small, Large, Massive };
-
-inline AreaClass ClassFromValue(float v) {
-    using enum AreaClass;
-    if (v >= 500.0f) return Massive;
-    if (v >= 100.0f) return Large;
-    if (v >= 50.0f) return Small;
-    return AreaClass::None;
-}
-
-inline const char* AreaSuffix(AreaClass c) {
-    using enum AreaClass;
-    switch (c) {
-        case Small:
-            return " in an area";
-        case Large:
-            return " in a large area";
-        case Massive:
-            return " in a massive area";
-        default:
-            return "";
-    }
-}
-
-inline AreaClass AreaFromMGEF_Expl_Proj_Spellmaking(const RE::EffectSetting* m) {
-    if (!m) return AreaClass::None;
-
-    if (auto const* expl = m->data.explosion) {
-        const float r = expl->data.radius;
-        return ClassFromValue(r);
+    inline void SetDesc(RE::EffectSetting* m, std::string_view s) {
+        m->magicItemDescription = RE::BSFixedString{s.data()};
     }
 
-    if (auto const* proj = m->data.projectileBase) {
-        const float w = proj->data.collisionRadius;
-        return ClassFromValue(w);
+    inline bool SameDesc(const RE::EffectSetting* m, std::string_view s) {
+        const char* cur = m ? m->magicItemDescription.c_str() : nullptr;
+        return cur && s == cur;
     }
 
-    return AreaClass::None;
-}
+    enum class AreaClass { None, Small, Large, Massive };
 
-inline bool HasDurationFlag(const RE::EffectSetting* m) noexcept {
-    using Flag = RE::EffectSetting::EffectSettingData::Flag;
-    return m && !m->data.flags.all(Flag::kNoDuration);
-}
+    inline AreaClass ClassFromValue(float v) {
+        using enum AreaClass;
+        if (v >= 500.0f) return Massive;
+        if (v >= 100.0f) return Large;
+        if (v >= 50.0f) return Small;
+        return AreaClass::None;
+    }
 
-inline bool IsConcentration(const RE::EffectSetting* m) noexcept {
-    return m && m->data.castingType == RE::MagicSystem::CastingType::kConcentration;
-}
+    inline const char* AreaSuffix(AreaClass c) {
+        using enum AreaClass;
+        switch (c) {
+            case Small:
+                return " in an area";
+            case Large:
+                return " in a large area";
+            case Massive:
+                return " in a massive area";
+            default:
+                return "";
+        }
+    }
 
-inline bool ShouldPrintDurationClause(const RE::EffectSetting* m) noexcept {
-    return HasDurationFlag(m) && !IsConcentration(m);
-}
+    inline AreaClass AreaFromMGEF_Expl_Proj_Spellmaking(const RE::EffectSetting* m) {
+        if (!m) return AreaClass::None;
 
-inline std::string BuildDVME_Desc(const RE::EffectSetting* m, float mult, bool frost) {
-    const auto fid = m->GetFormID();
-    const bool isWall = (fid == kWallFrost) || (fid == kWallShock);
-    const bool isCloak = (fid == kCloakFrost) || (fid == kCloakShock);
+        if (auto const* expl = m->data.explosion) {
+            const float r = expl->data.radius;
+            return ClassFromValue(r);
+        }
 
-    const bool perSec = WantsPerSecond(m);
-    const char* elem = frost ? "Frost" : "Shock";
-    const char* secAV = frost ? "Stamina" : "Magicka";
+        if (auto const* proj = m->data.projectileBase) {
+            const float w = proj->data.collisionRadius;
+            return ClassFromValue(w);
+        }
 
-    std::string s;
+        return AreaClass::None;
+    }
 
-    if (isWall) {
-        s += "Creates a wall that deals <mag> ";
+    inline bool ShouldPrintDurationClause(const RE::EffectSetting* m) noexcept {
+        if (!m) {
+            return false;
+        }
+
+        const auto& dnam = m->magicItemDescription;
+        if (dnam.empty()) {
+            return false;
+        }
+
+        const char* c = dnam.c_str();
+        if (!c || !*c) {
+            return false;
+        }
+
+        return std::string_view(c).contains("<dur>");
+    }
+
+    inline std::string BuildDVME_Desc(const RE::EffectSetting* m, float mult, bool frost) {
+        const auto fid = m->GetFormID();
+        const bool isWall = (fid == kWallFrost) || (fid == kWallShock);
+        const bool isCloak = (fid == kCloakFrost) || (fid == kCloakShock);
+
+        const bool perSec = WantsPerSecond(m);
+        const char* elem = frost ? "Frost" : "Shock";
+        const char* secAV = frost ? "Stamina" : "Magicka";
+
+        std::string s;
+
+        if (isWall) {
+            s += "Creates a wall that deals <mag> ";
+            s += elem;
+            s += " damage";
+            if (perSec) s += " per second";
+            if (mult <= 1e-6f) {
+                s += " to Health";
+            } else if (std::fabs(mult - 1.0f) < 1e-3f) {
+                s += " to Health and ";
+                s += secAV;
+            } else {
+                s += " to Health and <sec> to ";
+                s += secAV;
+            }
+            s += ".";
+            return s;
+        }
+
+        if (isCloak) {
+            s += "For <dur> seconds, nearby enemies take <mag> ";
+            s += elem;
+            s += " damage per second";
+            if (mult <= 1e-6f) {
+                s += " to Health";
+            } else if (std::fabs(mult - 1.0f) < 1e-3f) {
+                s += " to Health and ";
+                s += secAV;
+            } else {
+                s += " to Health and <sec> to ";
+                s += secAV;
+            }
+            s += ".";
+            return s;
+        }
+
+        s += "Deals <mag> ";
         s += elem;
         s += " damage";
         if (perSec) s += " per second";
+
         if (mult <= 1e-6f) {
             s += " to Health";
         } else if (std::fabs(mult - 1.0f) < 1e-3f) {
@@ -140,110 +184,110 @@ inline std::string BuildDVME_Desc(const RE::EffectSetting* m, float mult, bool f
             s += " to Health and <sec> to ";
             s += secAV;
         }
+        const AreaClass ac = AreaFromMGEF_Expl_Proj_Spellmaking(m);
+        s += AreaSuffix(ac);
+
+        if (ShouldPrintDurationClause(m)) s += " for <dur> seconds";
+
         s += ".";
         return s;
     }
 
-    if (isCloak) {
-        s += "For <dur> seconds, nearby enemies take <mag> ";
-        s += elem;
-        s += " damage per second";
-        if (mult <= 1e-6f) {
-            s += " to Health";
-        } else if (std::fabs(mult - 1.0f) < 1e-3f) {
-            s += " to Health and ";
-            s += secAV;
-        } else {
-            s += " to Health and <sec> to ";
-            s += secAV;
-        }
-        s += ".";
-        return s;
-    }
-
-    s += "Deals <mag> ";
-    s += elem;
-    s += " damage";
-    if (perSec) s += " per second";
-
-    if (mult <= 1e-6f) {
-        s += " to Health";
-    } else if (std::fabs(mult - 1.0f) < 1e-3f) {
-        s += " to Health and ";
-        s += secAV;
-    } else {
-        s += " to Health and <sec> to ";
-        s += secAV;
-    }
-    const AreaClass ac = AreaFromMGEF_Expl_Proj_Spellmaking(m);
-    s += AreaSuffix(ac);
-
-    if (ShouldPrintDurationClause(m)) s += " for <dur> seconds";
-
-    s += ".";
-    return s;
-}
-
-inline bool ci_contains(std::string_view hay, std::string_view needle) {
-    if (needle.empty() || needle.size() > hay.size()) return false;
-    for (size_t i = 0; i + needle.size() <= hay.size(); ++i) {
-        bool ok = true;
-        for (size_t j = 0; j < needle.size(); ++j) {
-            auto a = static_cast<unsigned char>(hay[i + j]);
-            auto b = static_cast<unsigned char>(needle[j]);
-            if (std::tolower(a) != std::tolower(b)) {
-                ok = false;
-                break;
-            }
-        }
-        if (ok) return true;
-    }
-    return false;
-}
-
-inline void TrimTrailingSpaces(std::string& s) {
-    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) s.pop_back();
-}
-
-inline bool EndsWithDot(std::string_view s) {
-    if (s.empty()) return false;
-    char c = s.back();
-    return c == '.' || c == '!' || c == '?';
-}
-
-inline void ApplyFireDescOne(RE::EffectSetting* m, float fireMult) {
-    const char* kExtraNeedle = "extra damage";
-    const char* kExtraSentence = " Targets on fire take extra damage over time.";
-
-    const char* curC = m->magicItemDescription.c_str();
-    std::string cur = curC ? curC : std::string{};
-    TrimTrailingSpaces(cur);
-
-    const bool hasExtra = ci_contains(cur, kExtraNeedle);
-
-    if (fireMult <= 1e-6f) {
-        if (hasExtra) {
-            const size_t dot = cur.find('.');
-            if (dot != std::string::npos) {
-                std::string onlyFirst = cur.substr(0, dot + 1);
-                if (!SameDesc(m, onlyFirst)) SetDesc(m, onlyFirst);
-            } else {
-                const size_t pos = cur.find(kExtraSentence);
-                if (pos != std::string::npos) {
-                    cur.erase(pos, std::strlen(kExtraSentence));
-                    TrimTrailingSpaces(cur);
-                    if (!EndsWithDot(cur)) cur += ".";
-                    if (!SameDesc(m, cur)) SetDesc(m, cur);
+    inline bool ci_contains(std::string_view hay, std::string_view needle) {
+        if (needle.empty() || needle.size() > hay.size()) return false;
+        for (size_t i = 0; i + needle.size() <= hay.size(); ++i) {
+            bool ok = true;
+            for (size_t j = 0; j < needle.size(); ++j) {
+                auto a = static_cast<unsigned char>(hay[i + j]);
+                auto b = static_cast<unsigned char>(needle[j]);
+                if (std::tolower(a) != std::tolower(b)) {
+                    ok = false;
+                    break;
                 }
             }
+            if (ok) return true;
         }
-        return;
+        return false;
     }
 
-    if (!hasExtra) {
-        if (!EndsWithDot(cur) && !cur.empty()) cur += ".";
+    inline void TrimTrailingSpaces(std::string& s) {
+        while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) s.pop_back();
+    }
+
+    inline bool EndsWithDot(std::string_view s) {
+        if (s.empty()) return false;
+        char c = s.back();
+        return c == '.' || c == '!' || c == '?';
+    }
+
+    inline bool IsFireDisabled(float fireMult) noexcept { return fireMult <= 1e-6f; }
+
+    inline void RemoveExtraSentenceFirstDot(RE::EffectSetting* m, std::string& cur) {
+        const size_t dot = cur.find('.');
+        if (dot == std::string::npos) {
+            return;
+        }
+
+        std::string onlyFirst = cur.substr(0, dot + 1);
+        if (!SameDesc(m, onlyFirst)) {
+            SetDesc(m, onlyFirst);
+        }
+    }
+
+    inline void RemoveExtraSentenceByPattern(RE::EffectSetting* m, std::string& cur) {
+        const size_t pos = cur.find(kExtraSentence);
+        if (pos == std::string::npos) {
+            return;
+        }
+
+        cur.erase(pos, std::strlen(kExtraSentence));
+        TrimTrailingSpaces(cur);
+        if (!EndsWithDot(cur)) {
+            cur += ".";
+        }
+
+        if (!SameDesc(m, cur)) {
+            SetDesc(m, cur);
+        }
+    }
+
+    inline void RemoveExtraDamageSentence(RE::EffectSetting* m, std::string& cur) {
+        if (cur.contains('.')) {
+            RemoveExtraSentenceFirstDot(m, cur);
+        } else {
+            RemoveExtraSentenceByPattern(m, cur);
+        }
+    }
+
+    inline void AddExtraDamageSentence(RE::EffectSetting* m, std::string& cur) {
+        if (!EndsWithDot(cur) && !cur.empty()) {
+            cur += ".";
+        }
+
         cur += kExtraSentence;
-        if (!SameDesc(m, cur)) SetDesc(m, cur);
+
+        if (!SameDesc(m, cur)) {
+            SetDesc(m, cur);
+        }
+    }
+
+    inline void ApplyFireDescOne(RE::EffectSetting* m, float fireMult) {
+        const char* curC = m->magicItemDescription.c_str();
+        std::string cur = curC ? curC : std::string{};
+        TrimTrailingSpaces(cur);
+
+        const bool hasExtra = ci_contains(cur, kExtraNeedle);
+
+        if (IsFireDisabled(fireMult)) {
+            if (hasExtra) {
+                RemoveExtraDamageSentence(m, cur);
+            }
+            return;
+        }
+
+        if (!hasExtra) {
+            AddExtraDamageSentence(m, cur);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust magic effect description handling and simplify hook instrumentation for formatted spell text.

Bug Fixes:
- Correct when duration clauses are added to magic effect descriptions by checking for the <dur> placeholder instead of relying solely on flags.
- Fix removal of the 'Targets on fire take extra damage over time.' sentence when fire damage scaling is disabled so only the intended sentence is stripped without truncating other text.

Enhancements:
- Refine construction of frost and shock effect descriptions, including special cases for wall and cloak effects and improved area and duration phrasing.
- Introduce reusable helpers for case-insensitive substring search, trimming, punctuation detection, and extra-fire-damage sentence manipulation.
- Mark MagFormatHook::StringData constructor explicit and modernize detour attach calls using init-statements to tighten variable scope.

Chores:
- Remove verbose debug logging and unused call hooks from MagFormatHook, leaving only the CallEffectB hook installed, and drop an unnecessary info log in the magic formatting path.